### PR TITLE
fixed error on admin order view

### DIFF
--- a/app/code/community/IyzicoCheckoutForm/IyzicoCheckoutForm/etc/config.xml
+++ b/app/code/community/IyzicoCheckoutForm/IyzicoCheckoutForm/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <IyzicoCheckoutForm_IyzicoCheckoutForm>
-            <version>1.0.1</version>
+            <version>1.1.0</version>
         </IyzicoCheckoutForm_IyzicoCheckoutForm>
     </modules>
 


### PR DESCRIPTION
Since the setup scripts were not executed, there was the following error when viewing an order in the backend:

    SQLSTATE[42S02]: Base table or view not found: 1146 Table 'db.iyzico_checkout_form_transaction_api_log' doesn't exist, query was: SELECT `main_table`.* FROM `iyzico_checkout_form_transaction_api_log` AS `main_table` WHERE (`order_increment_id` = '123456789')